### PR TITLE
ci: 为非 Draft PR 增加 CS144 单元测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CS144 CI
+
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cs144-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure Debug build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build --parallel 2
+
+      - name: Run unit and local FSM tests
+        run: |
+          ctest --test-dir build \
+            --output-on-failure \
+            --timeout 20 \
+            -R '^(t_byte_stream_|t_strm_reassem_|t_wrapping_ints_|t_recv_|t_send_|t_active_close$|t_passive_close$|t_ack_rst$|t_ack_rst_win$|t_connect$|t_listen$|t_winsize$|t_retx$|t_retx_win$|t_loopback$|t_loopback_win$|t_reorder$|t_address_dt$|t_parser_dt$|t_socket_dt$|arp_network_interface$|router_test$)'


### PR DESCRIPTION
## 实现内容

- 新增 `.github/workflows/ci.yml`，仅监听 `pull_request` 事件。
- 仅当 `github.event.pull_request.draft == false` 时执行测试 Job；Draft PR 不分配 Runner。
- 监听 `ready_for_review`，确保 PR 从 Draft 转为 Ready 后立即触发 CI。
- 监听 `converted_to_draft` 并结合同一 PR 的 `concurrency`，可取消仍在运行的旧 CI。
- 开启 `cancel-in-progress`，同一 PR 连续 push 时只保留最新一轮执行。
- 使用 GitHub Actions 原生 commit message skip 行为；`[skip ci]`、`[ci skip]` 等标准标记无需自定义解析。
- 使用 `actions/checkout@v6`、CMake Debug 构建，并执行适合 GitHub-hosted Runner 的本地单元测试和 TCPConnection FSM 测试。

## 实现说明

- workflow 不监听 `push`，避免普通分支提交重复触发；CI 只服务 Pull Request。
- Job 条件放在 Runner 分配前，Draft PR 只产生跳过状态，不消耗测试 Runner。
- 测试使用明确的 CTest 正则白名单，覆盖：
  - ByteStream
  - StreamReassembler
  - WrappingInt32
  - TCPReceiver
  - TCPSender
  - TCPConnection 本地 FSM
  - Address / Parser / Socket doctest
  - NetworkInterface 与 Router 单元测试
- 未执行 `t_webget`、`txrx.sh`、TUN/TAP 和公网相关测试，避免环境依赖造成非代码失败。

## 测试与验证

| 检查项 | 结果 |
|---|---|
| YAML 解析 | 通过：workflow 可被 YAML 解析，事件列表和 Draft 条件字段符合预期 |
| `master...ci/11-pr-unit-tests` diff | 通过：仅新增 `.github/workflows/ci.yml`，1 个提交，40 行 |
| GitHub Actions 实际构建与 CTest | 未运行：本 PR 按仓库规则保持 Draft；标记为 Ready for review 后才会触发 |

## 影响范围

- 仅影响 Pull Request 的 GitHub Actions 行为。
- 不修改 CS144 源码、测试实现、CMake 测试定义和本地开发命令。
- 不引入自托管 Runner、TUN/TAP 权限或公网依赖。

## 风险与注意事项

- GitHub 原生 `[skip ci]` 会让对应 workflow check 保持 Pending；若未来将此 Job 配置为 required check，带 skip 标记的 HEAD commit 可能阻塞合并，需要再推送一个不带 skip 标记的提交。
- 当前首次真实构建将在 PR 转为 Ready 后发生；若 Ubuntu Runner 的工具链暴露旧版项目兼容问题，应基于真实日志补充最小修复。

## 审阅重点

- `.github/workflows/ci.yml` 的事件集合与 Draft 条件是否完全符合预期。
- CTest 白名单是否覆盖需要的纯本地测试，同时排除了公网、TUN/TAP 和 `txrx.sh`。
- `converted_to_draft` 与 `cancel-in-progress` 的组合是否符合 Actions 使用量控制目标。

## 关联项

- Closes #11